### PR TITLE
Version 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use 'any' as file_extension to match all files.
 
 - `-h`, `--help`: Display help information
 - `-v`, `--version`: Display the version of `dump_dir`
-- `-s <directory>`: Skip specified directory
+- `-s <directory>, --skip <directory>`: Skip specified directory
 - `--include-ignored`: Include files that would normally be ignored (e.g., those in `.gitignore`)
 - `-m <size>`, `--max-filesize <size>`: Specify the maximum file size to process. You can use units like B, KB, or MB (e.g., 500KB, 2MB). If no unit is specified, it defaults to bytes.
 
@@ -36,7 +36,7 @@ Use 'any' as file_extension to match all files.
 
 Get all JS files, ignoring your node_modules and dist directories:
 ```bash
-dump_dir js ./project -s ./project/node_modules -s ./project/dist
+dump_dir js ./project -s ./project/node_modules --skip ./project/dist
 ```
 Get all files in your project directory of all types:
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,51 +12,51 @@ Copy a bunch of files into your clipboard to provide context for LLMs
 
 _Example: dump_dir-ing this repo_
 
-![image](https://github.com/user-attachments/assets/ae8bc680-8da0-4f50-9092-6b6f89a2a9ad)
+![image](https://github.com/user-attachments/assets/17e52273-871b-44a0-8f0b-10f91eb4ad25)
+
+
 
 ## 🚀 Usage
 
 
 ```bash
-dump_dir [options] <file_extension1> [,<file_extension2>,...] <directory1> [directory2] ... [-s <skip_directory1>] [-s <skip_directory2>] ... [--include-ignored]
+dump_dir <directory1> [directory2] ...
 ```
-
-Use 'any' as file_extension to match all files.
-
 
 #### 📚 Options
 
 - `-h`, `--help`: Display help information
 - `-v`, `--version`: Display the version of `dump_dir`
 - `-s <directory>, --skip <directory>`: Skip specified directory
+- `-e <extension[s]>, --extension <extension[s]>`: Filter by specific file extensions
 - `--include-ignored`: Include files that would normally be ignored (e.g., those in `.gitignore`)
 - `-m <size>`, `--max-filesize <size>`: Specify the maximum file size to process. You can use units like B, KB, or MB (e.g., 500KB, 2MB). If no unit is specified, it defaults to bytes.
 
 #### 📑 Examples
 
-Get all JS files, ignoring your node_modules and dist directories:
-```bash
-dump_dir js ./project -s ./project/node_modules --skip ./project/dist
-```
 Get all files in your project directory of all types:
 ```bash
-dump_dir any ./project
+dump_dir ./project
 ````
+Get all JS files, ignoring your dist directory:
+```bash
+dump_dir ./project -e js  --skip ./project/dist
+```
 Get all Go, JavaScript, and Python files in your project:
 ```bash
-dump_dir go,js,py ./project
+dump_dir ./project --extension go,js,py 
 ```
 Get all files, including those normally ignored (e.g., files in .gitignore):
 ```bash
-dump_dir any ./project --include-ignored
+dump_dir ./project --include-ignored
 ```
 Get specific files regardless of their extension:
 ```bash
-dump_dir any ./README.md ./main.go
+dump_dir ./README.md ./main.go --extension py
 ```
 Set a maximum file size of 1MB:
 ```bash
-dump_dir go ./project --max-filesize 1MB
+dump_dir ./project --max-filesize 1MB
 ```
 
 ## 🔒 Gitignore Behavior
@@ -71,6 +71,7 @@ To include ignored files, use the `--include-ignored` flag as shown in the examp
 ## 👉 Special Files Behavior
 
 By default, files are too large if they are >500KB. You can adjust this limit using the `-m` or `--max-filesize` option.
+If any files are skipped for any reason, `dump_dir` will inform you.
 
 | File type       | Output                          |
 |-----------------|---------------------------------|
@@ -99,6 +100,7 @@ Alternatively, you can manually download the latest release from the GitHub Rele
 
 For Windows users, please download the latest release from the GitHub Releases page and add it to your PATH manually.
 
+
 ## 💡 Tips for LLM Development
 
 - 📁 Use `dump_dir` to quickly gather context from multiple project files
@@ -107,7 +109,7 @@ For Windows users, please download the latest release from the GitHub Releases p
 
 ## 🤝 Contributing
 
-Raise an issue or make a PR, I whipped this up real quick so there's probably a lot of room for improvement.
+Raise an issue or make a PR. Run tests with `go test ./tests/...`
 
 ## 📜 License
 

--- a/src/args.go
+++ b/src/args.go
@@ -58,7 +58,7 @@ func ParseArgs(args []string) (Config, error) {
 		arg := args[i]
 		if arg == "--include-ignored" {
 			config.IncludeIgnored = true
-		} else if arg == "-s" {
+		} else if arg == "-s" || arg == "--skip" {
 			skipMode = true
 		} else if arg == "--max-filesize" || arg == "-m" {
 			if i+1 < len(args) {

--- a/src/args.go
+++ b/src/args.go
@@ -28,7 +28,7 @@ func ParseArgs(args []string) (Config, error) {
 		SkipDirs:      []string{},
 		SpecificFiles: []string{},
 		Directories:   []string{},
-		Extensions:    []string{},
+		Extensions:    []string{}, // Empty slice means all extensions
 		MaxFileSize:   500 * 1024, // Default to 500KB
 	}
 
@@ -42,25 +42,23 @@ func ParseArgs(args []string) (Config, error) {
 		return config, nil
 	}
 
-	// Check for help flag anywhere in the arguments
-	for _, arg := range args {
-		if arg == "--help" || arg == "-h" {
+	skipMode := false
+	extensionMode := false
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		switch arg {
+		case "--help", "-h":
 			config.Action = "help"
 			return config, nil
-		}
-	}
-
-	// If we're here, it's the default dump_dir action
-	config.Extensions = strings.Split(args[0], ",")
-
-	skipMode := false
-	for i := 1; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--include-ignored" {
+		case "--include-ignored":
 			config.IncludeIgnored = true
-		} else if arg == "-s" || arg == "--skip" {
+		case "-s", "--skip":
 			skipMode = true
-		} else if arg == "--max-filesize" || arg == "-m" {
+		case "-e", "--extension":
+			extensionMode = true
+		case "--max-filesize", "-m":
 			if i+1 < len(args) {
 				size, err := parseFileSize(args[i+1])
 				if err != nil {
@@ -71,26 +69,30 @@ func ParseArgs(args []string) (Config, error) {
 			} else {
 				return config, ErrInvalidMaxFileSize{Value: ""}
 			}
-		} else if skipMode {
-			config.SkipDirs = append(config.SkipDirs, arg)
-			skipMode = false
-		} else {
-			if fileInfo, err := OsStat(arg); err == nil {
-				if fileInfo.IsDir() {
-					config.Directories = append(config.Directories, arg)
-				} else {
-					config.SpecificFiles = append(config.SpecificFiles, arg)
-				}
+		default:
+			if skipMode {
+				config.SkipDirs = append(config.SkipDirs, arg)
+				skipMode = false
+			} else if extensionMode {
+				config.Extensions = append(config.Extensions, strings.Split(arg, ",")...)
+				extensionMode = false
 			} else {
-				// If we can't stat it, assume it's a directory
-				config.Directories = append(config.Directories, arg)
+				if fileInfo, err := OsStat(arg); err == nil {
+					if fileInfo.IsDir() {
+						config.Directories = append(config.Directories, arg)
+					} else {
+						config.SpecificFiles = append(config.SpecificFiles, arg)
+					}
+				} else {
+					// If we can't stat it, assume it's a directory
+					config.Directories = append(config.Directories, arg)
+				}
 			}
 		}
 	}
 
 	return config, nil
 }
-
 func parseFileSize(sizeStr string) (int64, error) {
 	sizeStr = strings.ToUpper(sizeStr)
 	var multiplier int64 = 1

--- a/src/file_finder.go
+++ b/src/file_finder.go
@@ -113,7 +113,7 @@ func (ff *FileFinder) isInSkipDirs(filePath string) bool {
 }
 
 func (ff *FileFinder) matchesExtensions(filename string) bool {
-	if len(ff.Config.Extensions) == 1 && ff.Config.Extensions[0] == "any" {
+	if len(ff.Config.Extensions) == 0 {
 		return true
 	}
 	for _, ext := range ff.Config.Extensions {

--- a/src/stats.go
+++ b/src/stats.go
@@ -2,13 +2,16 @@ package src
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
 func CalculateStats(processedFiles []FileInfo) Stats {
 	var totalLines, estimatedTokens int
 
-	for _, fileInfo := range processedFiles {
+	sortedFiles := SortFileList(processedFiles)
+
+	for _, fileInfo := range sortedFiles {
 		totalLines += strings.Count(fileInfo.Contents, "\n")
 		estimatedTokens += estimateTokens(fileInfo.Contents)
 	}
@@ -17,7 +20,7 @@ func CalculateStats(processedFiles []FileInfo) Stats {
 		TotalFiles:      len(processedFiles),
 		TotalLines:      totalLines,
 		EstimatedTokens: estimatedTokens,
-		ProcessedFiles:  processedFiles,
+		ProcessedFiles:  sortedFiles,
 	}
 }
 
@@ -46,4 +49,24 @@ func formatTokenCount(tokens int) string {
 	} else {
 		return fmt.Sprintf("%dk", tokens/1000)
 	}
+}
+
+func SortFileList(files []FileInfo) []FileInfo {
+	sort.Slice(files, func(i, j int) bool {
+		// Split the paths into components
+		pathI := strings.Split(files[i].Path, "/")
+		pathJ := strings.Split(files[j].Path, "/")
+
+		// Compare each component
+		for k := 0; k < len(pathI) && k < len(pathJ); k++ {
+			if pathI[k] != pathJ[k] {
+				return pathI[k] < pathJ[k]
+			}
+		}
+
+		// If all components are the same up to this point, shorter path comes first
+		return len(pathI) < len(pathJ)
+	})
+
+	return files
 }

--- a/src/stats.go
+++ b/src/stats.go
@@ -58,7 +58,6 @@ func printFileList(summary *strings.Builder, heading string, files []FileInfo) {
 	for _, file := range files {
 		summary.WriteString(fmt.Sprintf("- %s\n", file.Path))
 	}
-	summary.WriteString("\n")
 }
 
 func estimateTokens(content string) int {

--- a/src/types.go
+++ b/src/types.go
@@ -1,8 +1,17 @@
 package src
 
+type FileStatus string
+
+const (
+	StatusParsed          FileStatus = "PARSED"
+	StatusSkippedBinary   FileStatus = "SKIPPED_BINARY"
+	StatusSkippedTooLarge FileStatus = "SKIPPED_TOO_LARGE"
+)
+
 type FileInfo struct {
 	Path     string
 	Contents string
+	Status   FileStatus
 }
 
 type Config struct {
@@ -20,4 +29,7 @@ type Stats struct {
 	TotalLines      int
 	EstimatedTokens int
 	ProcessedFiles  []FileInfo
+	ParsedFiles     []FileInfo
+	SkippedLarge    []FileInfo
+	SkippedBinary   []FileInfo
 }

--- a/tests/args_test.go
+++ b/tests/args_test.go
@@ -50,7 +50,7 @@ func TestParseArgs(t *testing.T) {
 		},
 		{
 			name: "Skip directories",
-			args: []string{"go", "./src", "-s", "./src/vendor", "-s", "./src/generated"},
+			args: []string{"go", "./src", "-s", "./src/vendor", "--skip", "./src/generated"},
 			expectedConfig: BuildConfig(
 				WithAction("dump_dir"),
 				WithExtensions("go"),

--- a/tests/args_test.go
+++ b/tests/args_test.go
@@ -172,7 +172,7 @@ func TestParseArgs(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		if diff := cmp.Diff(expectedConfig, config); diff != "" {
+		if diff := cmp.Diff(expectedConfig, &config); diff != "" {
 			t.Errorf("ParseArgs() mismatch (-want +got):\n%s", diff)
 		}
 	})

--- a/tests/file_finder_test.go
+++ b/tests/file_finder_test.go
@@ -10,7 +10,7 @@ func TestFileFinder(t *testing.T) {
 	tests := []struct {
 		name            string
 		fileSystem      map[string]string
-		config          Config
+		config          *Config
 		expectedFiles   []string
 		unexpectedFiles []string
 	}{
@@ -138,7 +138,7 @@ func TestFileFinder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := setupTestFileSystem(tt.fileSystem)
-			fileFinder := NewFileFinder(tt.config, fs)
+			fileFinder := NewFileFinder(*tt.config, fs)
 
 			foundFiles := fileFinder.DiscoverFiles()
 

--- a/tests/ignore_test.go
+++ b/tests/ignore_test.go
@@ -14,7 +14,7 @@ func TestIgnoreFunctionality(t *testing.T) {
 		files           []string
 		globalGitignore string
 		localGitignore  string
-		config          Config
+		config          *Config
 		expectedFiles   []string
 		unexpectedFiles []string
 	}{
@@ -102,7 +102,7 @@ func TestIgnoreFunctionality(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fs := setupIgnoreTestEnvironment(tt.files, tt.globalGitignore, tt.localGitignore)
-			fileFinder := NewFileFinder(tt.config, fs)
+			fileFinder := NewFileFinder(*tt.config, fs)
 
 			foundFiles := fileFinder.DiscoverFiles()
 


### PR DESCRIPTION
## :owl: Overview

This PR includes various minor changes to improve the tool. 

This includes a breaking change to the usage.

**Changes**
- Files are now printed in order
- Files that have been skipped are now listed in the output
- File extension argument is no longer required
- `--skip` option has been added to match `-s`
- Documentation updates to reflect new arguments

## :warning: Breaking Change

You no longer need to include the file extensions when calling `dump_dir`, we will automatically grab all files with any extension.